### PR TITLE
Fix Dockerfile ENV syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ WORKDIR /app
 
 # 3. Tetapkan variabel lingkungan
 # Mencegah Python menulis file .pyc untuk menjaga image tetap bersih
-ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONDONTWRITEBYTECODE=1
 # Memastikan output dari Python tidak di-buffer, sehingga log langsung terlihat
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONUNBUFFERED=1
 
 # 4. Instal dependensi sistem jika ada (saat ini tidak ada, tapi ini tempatnya)
 # RUN apt-get update && apt-get install -y ...


### PR DESCRIPTION
## Summary
- update Dockerfile to use `ENV key=value` syntax, resolving build warnings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861f1c6eab88324a8702d32c5b724f4