### PR TITLE
Add .env.example with placeholders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+DATABASE_URL=sqlite:///./sql_app.db
+CELERY_BROKER_URL=redis://localhost:6379/0
+CELERY_RESULT_BACKEND=redis://localhost:6379/0
+SECRET_KEY=changeme
+ALLOWED_ORIGINS=http://localhost:3000
+SPOTIFY_CLIENT_ID=
+SPOTIFY_CLIENT_SECRET=
+OPENROUTER_API_KEY=
+SENTRY_DSN=
+ENVIRONMENT=development
+# Optional additional settings
+GENERATOR_MODEL_NAME=openrouter-default
+PLANNER_MODEL_NAME=openrouter-default
+APP_NAME=Dear Diary API
+APP_SITE_URL=http://localhost
+REDIS_HOST=localhost
+REDIS_PORT=6379

--- a/README.md
+++ b/README.md
@@ -26,5 +26,6 @@ gunicorn -w 4 -k uvicorn.workers.UvicornWorker app.main:app
 ## Configuration
 
 Copy `.env.example` to `.env` and edit the values before running the server.
-The example lists placeholders for all environment variables (e.g. `DATABASE_URL`,
-`OPENROUTER_API_KEY`, `SPOTIFY_CLIENT_ID`, and `SPOTIFY_CLIENT_SECRET`).
+The repository includes `.env.example` with placeholders for all environment
+variables (e.g. `DATABASE_URL`, `OPENROUTER_API_KEY`, `SPOTIFY_CLIENT_ID`, and
+`SPOTIFY_CLIENT_SECRET`).


### PR DESCRIPTION
## Summary
- document all environment variables in `.env.example`
- mention provided example environment file in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6861f58bb87c8324b96b63ed272c6b79