### PR TITLE
Fix duplicate migrations by preloading gunicorn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ EXPOSE 8000
 # 8. Jalankan aplikasi saat kontainer dimulai
 # Perintah ini sama dengan yang kita bahas di Langkah 1, tapi untuk dijalankan di dalam kontainer
 # Mengikat ke 0.0.0.0 agar dapat diakses dari luar kontainer
-CMD ["gunicorn", "-w", "4", "-k", "uvicorn.workers.UvicornWorker", "--bind", "0.0.0.0:8000", "app.main:app"]
+CMD ["gunicorn", "--preload", "-w", "4", "-k", "uvicorn.workers.UvicornWorker", "--bind", "0.0.0.0:8000", "app.main:app"]

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Run the development server from within this directory:
 ```bash
 uvicorn app.main:app --reload
 ```
-gunicorn -w 4 -k uvicorn.workers.UvicornWorker app.main:app
+gunicorn --preload -w 4 -k uvicorn.workers.UvicornWorker app.main:app
 
 ## Configuration
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   web:
     build: .
-    command: gunicorn -w 4 -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:8000 app.main:app
+    command: gunicorn --preload -w 4 -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:8000 app.main:app
     volumes:
       - .:/app
     environment:


### PR DESCRIPTION
## Summary
- add `--preload` to gunicorn commands
- update Dockerfile and docker-compose configuration
- show `--preload` in README example

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861f633f1cc83248709ffd455df99bd