### PR TITLE
Fix missing planner settings

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -24,6 +24,8 @@ class Settings(BaseSettings):
     PROJECT_NAME: str = "Dear Diary API"
     PROJECT_VERSION: str = "1.0.0"
     ENVIRONMENT: str = "development" # Default ke development, akan ditimpa di produksi
+    APP_NAME: str = "Dear Diary API"
+    APP_SITE_URL: str = "http://localhost"
 
     # Database & Redis - WAJIB ADA
     DATABASE_URL: str
@@ -36,7 +38,7 @@ class Settings(BaseSettings):
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 60 * 24 * 7  # 7 hari
 
     # Kredensial & Konfigurasi Layanan Eksternal
-    OPENROUTER_API_KEY: str
+    OPENROUTER_API_KEY: str | None = None
     PLANNER_MODEL_NAME: str = "deepseek/deepseek-chat-v3-0324"
     GENERATOR_MODEL_NAME: str = "deepseek/deepseek-chat-v3-0324"
     SPOTIFY_CLIENT_ID: str


### PR DESCRIPTION
## Summary
- add missing `APP_NAME` and `APP_SITE_URL` to the `Settings`
- allow `OPENROUTER_API_KEY` to be `None`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68624956f2b08324bde02222785a3ad5