### PR TITLE
Add scheduled quote generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,14 @@ Copy `.env.example` to `.env` and edit the values before running the server.
 The repository includes `.env.example` with placeholders for all environment
 variables (e.g. `DATABASE_URL`, `OPENROUTER_API_KEY`, `SPOTIFY_CLIENT_ID`, and
 `SPOTIFY_CLIENT_SECRET`).
+
+## Background tasks
+
+Motivational quotes are generated automatically using Celery. Ensure Redis is running and start the worker and beat processes alongside Uvicorn:
+
+```bash
+celery -A app.celery_app.celery_app worker --loglevel=info
+celery -A app.celery_app.celery_app beat --loglevel=info
+```
+
+The scheduled task `generate_quote_task` runs every 15 minutes and inserts a new quote based on recent journal moods.

--- a/app/celery_app.py
+++ b/app/celery_app.py
@@ -13,3 +13,11 @@ celery_app = Celery(
     backend=redis_url,
     include=["app.tasks"] # Tunjuk ke file tempat task didefinisikan
 )
+
+celery_app.conf.beat_schedule = {
+    "generate-quote": {
+        "task": "app.tasks.generate_quote_task",
+        "schedule": 60 * 15,
+    }
+}
+celery_app.conf.timezone = "UTC"

--- a/app/services/quote_generation_service.py
+++ b/app/services/quote_generation_service.py
@@ -1,0 +1,52 @@
+import httpx
+import structlog
+from fastapi import Depends
+from textwrap import dedent
+from typing import List, Dict, Tuple
+
+from app.core.config import Settings, settings
+
+
+class QuoteGenerationService:
+    def __init__(self, settings: Settings = Depends(lambda: settings)):
+        self.settings = settings
+        self.api_base_url = "https://openrouter.ai/api/v1"
+        self.log = structlog.get_logger(__name__)
+
+    async def _call_openrouter(self, model: str, messages: List[Dict[str, str]]) -> Dict:
+        headers = {"Authorization": f"Bearer {self.settings.OPENROUTER_API_KEY}"}
+        json_data = {"model": model, "messages": messages}
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{self.api_base_url}/chat/completions",
+                headers=headers,
+                json=json_data,
+                timeout=20.0,
+            )
+            response.raise_for_status()
+            return response.json()
+
+    async def generate_quote(self, mood: str) -> Tuple[str, str]:
+        """Return a motivational quote text and author."""
+        prompt = dedent(
+            f"""
+            Buat satu kutipan motivasi singkat sesuai suasana hati berikut: {mood}.
+            Jika relevan, sertakan nama penulis setelah tanda dash.
+            """
+        ).strip()
+
+        messages = [{"role": "system", "content": prompt}]
+
+        try:
+            data = await self._call_openrouter(
+                model=self.settings.GENERATOR_MODEL_NAME,
+                messages=messages,
+            )
+            content = data["choices"][0]["message"]["content"].strip()
+            if " - " in content:
+                text, author = content.split(" - ", 1)
+                return text.strip(), author.strip()
+            return content, "Unknown"
+        except Exception as e:
+            self.log.error("quote_generation_error", error=str(e))
+            return "", ""


### PR DESCRIPTION
## Summary
- add QuoteGenerationService for OpenRouter-based quotes
- create Celery task `generate_quote_task`
- schedule new task via Celery beat
- document running Celery worker and beat

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862596d519083248ff0070b29bcda3e