### PR TITLE
Add seed script usage to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ pip install -r requirements.txt
 > starting Uvicorn. Omitting it can lead to import errors such as
 > `ModuleNotFoundError` if required packages are missing.
 
+### Database setup
+
+Run Alembic migrations and seed the database with sample articles, audio tracks
+and quotes:
+
+```bash
+alembic upgrade head
+python app/db/seed.py
+```
+
 Run the development server from within this directory:
 
 ```bash


### PR DESCRIPTION
## Summary
- document running `app/db/seed.py` after migrations

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: pydantic settings ValidationError)*

------
https://chatgpt.com/codex/tasks/task_e_686273dd74bc8324b2b8911e7e6f52e4