### PR TITLE
Update docs for Render deployment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Repository Guidelines
+
+These instructions apply to all files in this repository.
+
+## Testing
+1. Install dependencies with `pip install -r requirements.txt`.
+2. Ensure the environment variables from `.env.example` are available when running tests.
+3. Run the full test suite using `pytest` before committing.
+
+## Documentation
+- Keep `README.md`, `TODO.md`, and deployment notes in sync with `render.yaml`.

--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ Run the development server from within this directory:
 
 ```bash
 uvicorn app.main:app --reload
-```
+
+# For production
 gunicorn --preload -w 4 -k uvicorn.workers.UvicornWorker app.main:app
+```
 
 ## Configuration
 
@@ -40,3 +42,9 @@ celery -A app.celery_app.celery_app beat --loglevel=info
 ```
 
 The scheduled task `generate_quote_task` runs every 15 minutes and inserts a new quote based on recent journal moods.
+
+## Deployment on Render
+
+The `render.yaml` file provisions the services required to run the API on [Render](https://render.com/): a Postgres database, a Redis instance, the FastAPI web service and a Celery worker. Connect your GitHub repository on Render and it will automatically create these resources.
+
+Secrets referenced in `render.yaml` should be stored in the environment group `dear-diary-secrets`. During each deploy Render executes `build.sh` which installs dependencies and applies Alembic migrations.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,5 @@
+# TODO
+
+- [ ] Add tests for Celery background tasks.
+- [ ] Document how to set up the `dear-diary-secrets` environment group on Render.
+- [ ] Expand README with troubleshooting tips for deployment.


### PR DESCRIPTION
## Summary
- document production `gunicorn` usage
- add Render deployment section to README
- add TODO list for deployment-related tasks
- add repository guidelines in AGENTS.md

## Testing
- `set -a; source .env.example; set +a; pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68627513074483248e53611fced610a9